### PR TITLE
fix: Add packets to queue before open connection call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Add parameters to triggers
+* Add packets to queue before open connection call
 
 ## 2022-04-20 v1.2.0
 

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -161,22 +161,17 @@ export class ConnectionService {
     try {
       this.cancelScheduler();
 
-      if (this.isActive()) {
-        return this.write(getPacket);
+      if (!this.isActive() && !this.isAutoReconnected()) {
+        throw Error('Unable to send data due inactive connection');
       }
 
-      if (this.isAutoReconnected()) {
-        await this.open();
-        return this.write(getPacket);
-      }
-
-      throw Error('Unable to send data due inactive connection');
+      return this.write(getPacket);
     } catch (err) {
       this.onError(err);
     }
   }
 
-  private write(getPacket: () => ProtoPacket) {
+  private async write(getPacket: () => ProtoPacket) {
     let packet: ProtoPacket;
 
     const resolvePacket = () =>
@@ -213,6 +208,8 @@ export class ConnectionService {
           packet = protoPacket;
         },
       });
+
+      await this.open();
     }
 
     return resolvePacket();


### PR DESCRIPTION
Make the same as was done for the Web SDK.
It guarantees the correct order of packets.