### PR TITLE
Mark `setGenerateSessionToken` as deprecated instead of `generateSessionToken`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Add parameters to triggers
+* Mark `setGenerateSessionToken` as deprecated instead of `generateSessionToken` 
 
 ## 2022-04-20 v1.2.0
 

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -160,7 +160,7 @@ export class InworldClient {
   }
 }
 
-InworldClient.prototype.generateSessionToken = util.deprecate(
-  InworldClient.prototype.generateSessionToken,
+InworldClient.prototype.setGenerateSessionToken = util.deprecate(
+  InworldClient.prototype.setGenerateSessionToken,
   'setGenerateSessionToken() is deprecated. Use setOnSession() instead to manage session.',
 );


### PR DESCRIPTION
Fix typo in prev release
setGenerateSessionToken should be deprecated