### PR TITLE
feat: Replace checking emotions behavior and strength by direct property access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 * Add parameters to triggers
 * Mark `setGenerateSessionToken` as deprecated instead of `generateSessionToken` 
 * Add packets to queue before open connection call
+* Replace checking emotions behavior and strength by direct property access
 
 ## 2022-04-20 v1.2.0
 

--- a/__tests__/entities/emotion-behavior.entity.spec.ts
+++ b/__tests__/entities/emotion-behavior.entity.spec.ts
@@ -1,117 +1,225 @@
 import { EmotionEvent } from '@proto/packets_pb';
 
-import { EmotionBehavior } from '../../src/entities/emotion-behavior.entity';
+import {
+  EmotionBehavior,
+  EmotionBehaviorCode,
+} from '../../src/entities/emotion-behavior.entity';
+
+const mappingTestTable = [
+  {
+    input: EmotionEvent.SpaffCode.NEUTRAL,
+    expected: EmotionBehaviorCode.NEUTRAL,
+  },
+  {
+    input: EmotionEvent.SpaffCode.DISGUST,
+    expected: EmotionBehaviorCode.DISGUST,
+  },
+  {
+    input: EmotionEvent.SpaffCode.CONTEMPT,
+    expected: EmotionBehaviorCode.CONTEMPT,
+  },
+  {
+    input: EmotionEvent.SpaffCode.BELLIGERENCE,
+    expected: EmotionBehaviorCode.BELLIGERENCE,
+  },
+  {
+    input: EmotionEvent.SpaffCode.DOMINEERING,
+    expected: EmotionBehaviorCode.DOMINEERING,
+  },
+  {
+    input: EmotionEvent.SpaffCode.CRITICISM,
+    expected: EmotionBehaviorCode.CRITICISM,
+  },
+  {
+    input: EmotionEvent.SpaffCode.ANGER,
+    expected: EmotionBehaviorCode.ANGER,
+  },
+  {
+    input: EmotionEvent.SpaffCode.TENSION,
+    expected: EmotionBehaviorCode.TENSION,
+  },
+  {
+    input: EmotionEvent.SpaffCode.TENSE_HUMOR,
+    expected: EmotionBehaviorCode.TENSE_HUMOR,
+  },
+  {
+    input: EmotionEvent.SpaffCode.DEFENSIVENESS,
+    expected: EmotionBehaviorCode.DEFENSIVENESS,
+  },
+  {
+    input: EmotionEvent.SpaffCode.WHINING,
+    expected: EmotionBehaviorCode.WHINING,
+  },
+  {
+    input: EmotionEvent.SpaffCode.SADNESS,
+    expected: EmotionBehaviorCode.SADNESS,
+  },
+  {
+    input: EmotionEvent.SpaffCode.STONEWALLING,
+    expected: EmotionBehaviorCode.STONEWALLING,
+  },
+  {
+    input: EmotionEvent.SpaffCode.INTEREST,
+    expected: EmotionBehaviorCode.INTEREST,
+  },
+  {
+    input: EmotionEvent.SpaffCode.VALIDATION,
+    expected: EmotionBehaviorCode.VALIDATION,
+  },
+  {
+    input: EmotionEvent.SpaffCode.AFFECTION,
+    expected: EmotionBehaviorCode.AFFECTION,
+  },
+  {
+    input: EmotionEvent.SpaffCode.HUMOR,
+    expected: EmotionBehaviorCode.HUMOR,
+  },
+  {
+    input: EmotionEvent.SpaffCode.SURPRISE,
+    expected: EmotionBehaviorCode.SURPRISE,
+  },
+  {
+    input: EmotionEvent.SpaffCode.JOY,
+    expected: EmotionBehaviorCode.JOY,
+  },
+];
 
 test('should be neutral', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.NEUTRAL);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.NEUTRAL);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.NEUTRAL);
   expect(behavior.isNeutral()).toEqual(true);
 });
 
 test('should be disgust', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.DISGUST);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.DISGUST);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.DISGUST);
   expect(behavior.isDisgust()).toEqual(true);
 });
 
 test('should be contempt', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.CONTEMPT);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.CONTEMPT);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.CONTEMPT);
   expect(behavior.isContempt()).toEqual(true);
 });
 
 test('should be belligerence', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.BELLIGERENCE);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.BELLIGERENCE);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.BELLIGERENCE);
   expect(behavior.isBelligerence()).toEqual(true);
 });
 
 test('should be domineering', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.DOMINEERING);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.DOMINEERING);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.DOMINEERING);
   expect(behavior.isDomineering()).toEqual(true);
 });
 
 test('should be criticism', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.CRITICISM);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.CRITICISM);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.CRITICISM);
   expect(behavior.isCriticism()).toEqual(true);
 });
 
 test('should be anger', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.ANGER);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.ANGER);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.ANGER);
   expect(behavior.isAnger()).toEqual(true);
 });
 
 test('should be tension', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.TENSION);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.TENSION);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.TENSION);
   expect(behavior.isTension()).toEqual(true);
 });
 
 test('should be tense humor', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.TENSE_HUMOR);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.TENSE_HUMOR);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.TENSE_HUMOR);
   expect(behavior.isTenseHumor()).toEqual(true);
 });
 
 test('should be defensiveness', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.DEFENSIVENESS);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.DEFENSIVENESS);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.DEFENSIVENESS);
   expect(behavior.isDefensiveness()).toEqual(true);
 });
 
 test('should be whining', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.WHINING);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.WHINING);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.WHINING);
   expect(behavior.isWhining()).toEqual(true);
 });
 
 test('should be sadness', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.SADNESS);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.SADNESS);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.SADNESS);
   expect(behavior.isSadness()).toEqual(true);
 });
 
 test('should be stonewalling', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.STONEWALLING);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.STONEWALLING);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.STONEWALLING);
   expect(behavior.isStonewalling()).toEqual(true);
 });
 
 test('should be interest', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.INTEREST);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.INTEREST);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.INTEREST);
   expect(behavior.isInterest()).toEqual(true);
 });
 
 test('should be validation', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.VALIDATION);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.VALIDATION);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.VALIDATION);
   expect(behavior.isValidation()).toEqual(true);
 });
 
 test('should be affection', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.AFFECTION);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.AFFECTION);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.AFFECTION);
   expect(behavior.isAffection()).toEqual(true);
 });
 
 test('should be humor', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.HUMOR);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.HUMOR);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.HUMOR);
   expect(behavior.isHumor()).toEqual(true);
 });
 
 test('should be surprise', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.SURPRISE);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.SURPRISE);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.SURPRISE);
   expect(behavior.isSurprise()).toEqual(true);
 });
 
 test('should be joy', () => {
-  const behavior = new EmotionBehavior(EmotionEvent.SpaffCode.JOY);
+  const behavior = new EmotionBehavior(EmotionBehaviorCode.JOY);
 
+  expect(behavior.code).toEqual(EmotionBehaviorCode.JOY);
   expect(behavior.isJoy()).toEqual(true);
 });
+
+test.each(mappingTestTable)(
+  'should correctly convert $input',
+  ({ input, expected }) => {
+    expect(EmotionBehavior.fromProto(input)).toEqual(expected);
+  },
+);

--- a/__tests__/entities/emotion-strength.entity.spec.ts
+++ b/__tests__/entities/emotion-strength.entity.spec.ts
@@ -1,15 +1,58 @@
 import { EmotionEvent } from '@proto/packets_pb';
 
-import { EmotionStrength } from '../../src/entities/emotion-strength.entity';
+import {
+  EmotionStrength,
+  EmotionStrengthCode,
+} from '../../src/entities/emotion-strength.entity';
+
+const mappingTestTable = [
+  {
+    input: EmotionEvent.Strength.WEAK,
+    expected: EmotionStrengthCode.WEAK,
+  },
+  {
+    input: EmotionEvent.Strength.STRONG,
+    expected: EmotionStrengthCode.STRONG,
+  },
+  {
+    input: EmotionEvent.Strength.NORMAL,
+    expected: EmotionStrengthCode.NORMAL,
+  },
+  {
+    input: EmotionEvent.Strength.UNSPECIFIED,
+    expected: EmotionStrengthCode.UNSPECIFIED,
+  },
+];
 
 test('should be weak', () => {
-  const strength = new EmotionStrength(EmotionEvent.Strength.WEAK);
+  const strength = new EmotionStrength(EmotionStrengthCode.WEAK);
 
+  expect(strength.code).toEqual(EmotionStrengthCode.WEAK);
   expect(strength.isWeak()).toEqual(true);
 });
 
-test('should be disgust', () => {
-  const behavior = new EmotionStrength(EmotionEvent.Strength.STRONG);
+test('should be strong', () => {
+  const strength = new EmotionStrength(EmotionStrengthCode.STRONG);
 
-  expect(behavior.isStrong()).toEqual(true);
+  expect(strength.code).toEqual(EmotionStrengthCode.STRONG);
+  expect(strength.isStrong()).toEqual(true);
 });
+
+test('should be normal', () => {
+  const strength = new EmotionStrength(EmotionStrengthCode.NORMAL);
+
+  expect(strength.code).toEqual(EmotionStrengthCode.NORMAL);
+});
+
+test('should be unspecified', () => {
+  const strength = new EmotionStrength(EmotionStrengthCode.UNSPECIFIED);
+
+  expect(strength.code).toEqual(EmotionStrengthCode.UNSPECIFIED);
+});
+
+test.each(mappingTestTable)(
+  'should correctly convert $input',
+  ({ input, expected }) => {
+    expect(EmotionStrength.fromProto(input)).toEqual(expected);
+  },
+);

--- a/src/entities/emotion-behavior.entity.ts
+++ b/src/entities/emotion-behavior.entity.ts
@@ -1,85 +1,247 @@
+import util = require('node:util');
+
 import { EmotionEvent } from '@proto/packets_pb';
 
-export class EmotionBehavior {
-  private behavior: EmotionEvent.SpaffCode;
+export enum EmotionBehaviorCode {
+  NEUTRAL = 'NEUTRAL',
+  DISGUST = 'DISGUST',
+  CONTEMPT = 'CONTEMPT',
+  BELLIGERENCE = 'BELLIGERENCE',
+  DOMINEERING = 'DOMINEERING',
+  CRITICISM = 'CRITICISM',
+  ANGER = 'ANGER',
+  TENSION = 'TENSION',
+  TENSE_HUMOR = 'TENSE_HUMOR',
+  DEFENSIVENESS = 'DEFENSIVENESS',
+  WHINING = 'WHINING',
+  SADNESS = 'SADNESS',
+  STONEWALLING = 'STONEWALLING',
+  INTEREST = 'INTEREST',
+  VALIDATION = 'VALIDATION',
+  AFFECTION = 'AFFECTION',
+  HUMOR = 'HUMOR',
+  SURPRISE = 'SURPRISE',
+  JOY = 'JOY',
+}
 
-  constructor(behavior: EmotionEvent.SpaffCode) {
-    this.behavior = behavior;
+export class EmotionBehavior {
+  readonly code: EmotionBehaviorCode;
+
+  constructor(behavior: EmotionBehaviorCode) {
+    this.code = behavior;
   }
 
   isNeutral() {
-    return this.behavior === EmotionEvent.SpaffCode.NEUTRAL;
+    return this.code === EmotionBehaviorCode.NEUTRAL;
   }
 
   isDisgust() {
-    return this.behavior === EmotionEvent.SpaffCode.DISGUST;
+    return this.code === EmotionBehaviorCode.DISGUST;
   }
 
   isContempt() {
-    return this.behavior === EmotionEvent.SpaffCode.CONTEMPT;
+    return this.code === EmotionBehaviorCode.CONTEMPT;
   }
 
   isBelligerence() {
-    return this.behavior === EmotionEvent.SpaffCode.BELLIGERENCE;
+    return this.code === EmotionBehaviorCode.BELLIGERENCE;
   }
 
   isDomineering() {
-    return this.behavior === EmotionEvent.SpaffCode.DOMINEERING;
+    return this.code === EmotionBehaviorCode.DOMINEERING;
   }
 
   isCriticism() {
-    return this.behavior === EmotionEvent.SpaffCode.CRITICISM;
+    return this.code === EmotionBehaviorCode.CRITICISM;
   }
 
   isAnger() {
-    return this.behavior === EmotionEvent.SpaffCode.ANGER;
+    return this.code === EmotionBehaviorCode.ANGER;
   }
 
   isTension() {
-    return this.behavior === EmotionEvent.SpaffCode.TENSION;
+    return this.code === EmotionBehaviorCode.TENSION;
   }
 
   isTenseHumor() {
-    return this.behavior === EmotionEvent.SpaffCode.TENSE_HUMOR;
+    return this.code === EmotionBehaviorCode.TENSE_HUMOR;
   }
 
   isDefensiveness() {
-    return this.behavior === EmotionEvent.SpaffCode.DEFENSIVENESS;
+    return this.code === EmotionBehaviorCode.DEFENSIVENESS;
   }
 
   isWhining() {
-    return this.behavior === EmotionEvent.SpaffCode.WHINING;
+    return this.code === EmotionBehaviorCode.WHINING;
   }
 
   isSadness() {
-    return this.behavior === EmotionEvent.SpaffCode.SADNESS;
+    return this.code === EmotionBehaviorCode.SADNESS;
   }
 
   isStonewalling() {
-    return this.behavior === EmotionEvent.SpaffCode.STONEWALLING;
+    return this.code === EmotionBehaviorCode.STONEWALLING;
   }
 
   isInterest() {
-    return this.behavior === EmotionEvent.SpaffCode.INTEREST;
+    return this.code === EmotionBehaviorCode.INTEREST;
   }
 
   isValidation() {
-    return this.behavior === EmotionEvent.SpaffCode.VALIDATION;
+    return this.code === EmotionBehaviorCode.VALIDATION;
   }
 
   isAffection() {
-    return this.behavior === EmotionEvent.SpaffCode.AFFECTION;
+    return this.code === EmotionBehaviorCode.AFFECTION;
   }
 
   isHumor() {
-    return this.behavior === EmotionEvent.SpaffCode.HUMOR;
+    return this.code === EmotionBehaviorCode.HUMOR;
   }
 
   isSurprise() {
-    return this.behavior === EmotionEvent.SpaffCode.SURPRISE;
+    return this.code === EmotionBehaviorCode.SURPRISE;
   }
 
   isJoy() {
-    return this.behavior === EmotionEvent.SpaffCode.JOY;
+    return this.code === EmotionBehaviorCode.JOY;
+  }
+
+  static fromProto(code: EmotionEvent.SpaffCode) {
+    switch (code) {
+      case EmotionEvent.SpaffCode.NEUTRAL:
+        return EmotionBehaviorCode.NEUTRAL;
+      case EmotionEvent.SpaffCode.DISGUST:
+        return EmotionBehaviorCode.DISGUST;
+      case EmotionEvent.SpaffCode.CONTEMPT:
+        return EmotionBehaviorCode.CONTEMPT;
+      case EmotionEvent.SpaffCode.BELLIGERENCE:
+        return EmotionBehaviorCode.BELLIGERENCE;
+      case EmotionEvent.SpaffCode.DOMINEERING:
+        return EmotionBehaviorCode.DOMINEERING;
+      case EmotionEvent.SpaffCode.CRITICISM:
+        return EmotionBehaviorCode.CRITICISM;
+      case EmotionEvent.SpaffCode.ANGER:
+        return EmotionBehaviorCode.ANGER;
+      case EmotionEvent.SpaffCode.TENSION:
+        return EmotionBehaviorCode.TENSION;
+      case EmotionEvent.SpaffCode.TENSE_HUMOR:
+        return EmotionBehaviorCode.TENSE_HUMOR;
+      case EmotionEvent.SpaffCode.DEFENSIVENESS:
+        return EmotionBehaviorCode.DEFENSIVENESS;
+      case EmotionEvent.SpaffCode.WHINING:
+        return EmotionBehaviorCode.WHINING;
+      case EmotionEvent.SpaffCode.SADNESS:
+        return EmotionBehaviorCode.SADNESS;
+      case EmotionEvent.SpaffCode.STONEWALLING:
+        return EmotionBehaviorCode.STONEWALLING;
+      case EmotionEvent.SpaffCode.INTEREST:
+        return EmotionBehaviorCode.INTEREST;
+      case EmotionEvent.SpaffCode.VALIDATION:
+        return EmotionBehaviorCode.VALIDATION;
+      case EmotionEvent.SpaffCode.AFFECTION:
+        return EmotionBehaviorCode.AFFECTION;
+      case EmotionEvent.SpaffCode.HUMOR:
+        return EmotionBehaviorCode.HUMOR;
+      case EmotionEvent.SpaffCode.SURPRISE:
+        return EmotionBehaviorCode.SURPRISE;
+      case EmotionEvent.SpaffCode.JOY:
+        return EmotionBehaviorCode.JOY;
+    }
   }
 }
+
+EmotionBehavior.prototype.isNeutral = util.deprecate(
+  EmotionBehavior.prototype.isNeutral,
+  'isNeutral() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isDisgust = util.deprecate(
+  EmotionBehavior.prototype.isDisgust,
+  'isDisgust() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isContempt = util.deprecate(
+  EmotionBehavior.prototype.isContempt,
+  'isContempt() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isBelligerence = util.deprecate(
+  EmotionBehavior.prototype.isBelligerence,
+  'isBelligerence() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isDomineering = util.deprecate(
+  EmotionBehavior.prototype.isDomineering,
+  'isDomineering() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isCriticism = util.deprecate(
+  EmotionBehavior.prototype.isCriticism,
+  'isCriticism() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isAnger = util.deprecate(
+  EmotionBehavior.prototype.isAnger,
+  'isAnger() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isTension = util.deprecate(
+  EmotionBehavior.prototype.isTension,
+  'isTension() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isTenseHumor = util.deprecate(
+  EmotionBehavior.prototype.isTenseHumor,
+  'isTenseHumor() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isDefensiveness = util.deprecate(
+  EmotionBehavior.prototype.isDefensiveness,
+  'isDefensiveness() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isWhining = util.deprecate(
+  EmotionBehavior.prototype.isWhining,
+  'isWhining() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isSadness = util.deprecate(
+  EmotionBehavior.prototype.isSadness,
+  'isSadness() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isStonewalling = util.deprecate(
+  EmotionBehavior.prototype.isStonewalling,
+  'isStonewalling() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isInterest = util.deprecate(
+  EmotionBehavior.prototype.isInterest,
+  'isInterest() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isValidation = util.deprecate(
+  EmotionBehavior.prototype.isValidation,
+  'isValidation() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isAffection = util.deprecate(
+  EmotionBehavior.prototype.isAffection,
+  'isAffection() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isHumor = util.deprecate(
+  EmotionBehavior.prototype.isHumor,
+  'isHumor() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isSurprise = util.deprecate(
+  EmotionBehavior.prototype.isSurprise,
+  'isSurprise() is deprecated. Use code property instead.',
+);
+
+EmotionBehavior.prototype.isJoy = util.deprecate(
+  EmotionBehavior.prototype.isJoy,
+  'isJoy() is deprecated. Use code property instead.',
+);

--- a/src/entities/emotion-strength.entity.ts
+++ b/src/entities/emotion-strength.entity.ts
@@ -1,17 +1,49 @@
+import util = require('node:util');
+
 import { EmotionEvent } from '@proto/packets_pb';
 
-export class EmotionStrength {
-  private strength: EmotionEvent.Strength;
+export enum EmotionStrengthCode {
+  UNSPECIFIED = 'UNSPECIFIED',
+  WEAK = 'WEAK',
+  STRONG = 'STRONG',
+  NORMAL = 'NORMAL',
+}
 
-  constructor(strength: EmotionEvent.Strength) {
-    this.strength = strength;
+export class EmotionStrength {
+  readonly code: EmotionStrengthCode;
+
+  constructor(strength: EmotionStrengthCode) {
+    this.code = strength;
   }
 
   isWeak() {
-    return this.strength === EmotionEvent.Strength.WEAK;
+    return this.code === EmotionStrengthCode.WEAK;
   }
 
   isStrong() {
-    return this.strength === EmotionEvent.Strength.STRONG;
+    return this.code === EmotionStrengthCode.STRONG;
+  }
+
+  static fromProto(code: EmotionEvent.Strength) {
+    switch (code) {
+      case EmotionEvent.Strength.UNSPECIFIED:
+        return EmotionStrengthCode.UNSPECIFIED;
+      case EmotionEvent.Strength.WEAK:
+        return EmotionStrengthCode.WEAK;
+      case EmotionEvent.Strength.STRONG:
+        return EmotionStrengthCode.STRONG;
+      case EmotionEvent.Strength.NORMAL:
+        return EmotionStrengthCode.NORMAL;
+    }
   }
 }
+
+EmotionStrength.prototype.isWeak = util.deprecate(
+  EmotionStrength.prototype.isWeak,
+  'isWeak() is deprecated. Use code property instead.',
+);
+
+EmotionStrength.prototype.isStrong = util.deprecate(
+  EmotionStrength.prototype.isStrong,
+  'isStrong() is deprecated. Use code property instead.',
+);

--- a/src/factories/event.ts
+++ b/src/factories/event.ts
@@ -173,8 +173,12 @@ export class EventFactory {
       }),
       ...(type === InworldPacketType.EMOTION && {
         emotions: {
-          behavior: new EmotionBehavior(emotionEvent.getBehavior()),
-          strength: new EmotionStrength(emotionEvent.getStrength()),
+          behavior: new EmotionBehavior(
+            EmotionBehavior.fromProto(emotionEvent.getBehavior()),
+          ),
+          strength: new EmotionStrength(
+            EmotionStrength.fromProto(emotionEvent.getStrength()),
+          ),
         },
       }),
       ...(type === InworldPacketType.CANCEL_RESPONSE && {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,14 @@ import {
   User,
 } from './common/interfaces';
 import { Character } from './entities/character.entity';
-import { EmotionBehavior } from './entities/emotion-behavior.entity';
-import { EmotionStrength } from './entities/emotion-strength.entity';
+import {
+  EmotionBehavior,
+  EmotionBehaviorCode,
+} from './entities/emotion-behavior.entity';
+import {
+  EmotionStrength,
+  EmotionStrengthCode,
+} from './entities/emotion-strength.entity';
 import {
   Actor,
   AudioEvent,
@@ -57,7 +63,9 @@ export {
   ClientConfiguration,
   ConnectionConfig,
   EmotionBehavior,
+  EmotionBehaviorCode,
   EmotionStrength,
+  EmotionStrengthCode,
   getEngineHost,
   getStudioHost,
   InworlControlType,


### PR DESCRIPTION
Reduces the number of conversions
It's easier to get behavior or strength code directly from property

For example:
Old usage:
`packet.emotions.behavior.isAnger()`
New usage:
`packet.emotions.behavior.code === EmotionBehaviorCode.ANGER`

Mark all old fn calls as deprecated