### PR TITLE
feat: Allow to extend packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Allow to use extended capabilities and scene props
+* Allow to send and receive custom proto packet
+
 ## 2022-04-26 v1.3.1
 * Fix type definition for `onSession` method
 

--- a/__tests__/clients/inworld.client.extension.spec.ts
+++ b/__tests__/clients/inworld.client.extension.spec.ts
@@ -1,0 +1,34 @@
+import { InworldClient } from '../../src/clients/inworld.client';
+import { ConnectionService } from '../../src/services/connection.service';
+import { ExtendedInworldPacket } from '../data_structures';
+import {
+  extendedCapabilities,
+  extension,
+  KEY,
+  SCENE,
+  SECRET,
+} from '../helpers';
+
+jest.mock('../../src/services/connection.service');
+
+describe('extension', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should use extended capabilities', () => {
+    const inworldClient = new InworldClient<ExtendedInworldPacket>()
+      .setApiKey({ key: KEY, secret: SECRET })
+      .setScene(SCENE)
+      .setExtension(extension);
+
+    inworldClient.build();
+
+    expect(ConnectionService).toHaveBeenCalledTimes(1);
+    expect(ConnectionService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: { capabilities: extendedCapabilities },
+      }),
+    );
+  });
+});

--- a/__tests__/clients/inworld.client.spec.ts
+++ b/__tests__/clients/inworld.client.spec.ts
@@ -1,5 +1,5 @@
 import { InworldClient } from '../../src/clients/inworld.client';
-import { GetterSetter } from '../../src/common/interfaces';
+import { GetterSetter } from '../../src/common/data_structures';
 import { Session } from '../../src/entities/session.entity';
 import { TokenClientGrpcService } from '../../src/services/gprc/token_client_grpc.service';
 import {

--- a/__tests__/data_structures.ts
+++ b/__tests__/data_structures.ts
@@ -1,0 +1,13 @@
+import { InworldPacket } from '../src/entities/inworld_packet.entity';
+
+export interface RegenerateResponse {
+  interactionId?: string;
+}
+
+export interface MutationEvent {
+  regenerateResponse?: RegenerateResponse;
+}
+
+export interface ExtendedInworldPacket extends InworldPacket {
+  mutation: MutationEvent;
+}

--- a/__tests__/factories/event.spec.ts
+++ b/__tests__/factories/event.spec.ts
@@ -190,28 +190,28 @@ describe('convert packet to external one', () => {
       .setRouting(rounting)
       .setTimestamp(protoTimestamp())
       .setDataChunk(dataChunk);
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isAudio()).toEqual(true);
   });
 
   test('text', () => {
-    const result = EventFactory.fromProto(factory.text(v4()));
+    const result = InworldPacket.fromProto(factory.text(v4()));
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isText()).toEqual(true);
   });
 
   test('trigger without parameters', () => {
-    const result = EventFactory.fromProto(factory.trigger(v4()));
+    const result = InworldPacket.fromProto(factory.trigger(v4()));
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isTrigger()).toEqual(true);
   });
 
   test('trigger with parameters', () => {
-    const result = EventFactory.fromProto(
+    const result = InworldPacket.fromProto(
       factory.trigger(v4(), [{ name: v4(), value: v4() }]),
     );
 
@@ -230,7 +230,7 @@ describe('convert packet to external one', () => {
       .setTimestamp(protoTimestamp())
       .setEmotion(new EmotionEvent());
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isEmotion()).toEqual(true);
@@ -248,7 +248,7 @@ describe('convert packet to external one', () => {
       .setRouting(rounting)
       .setTimestamp(protoTimestamp())
       .setDataChunk(dataChunk);
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isSilence()).toEqual(true);
@@ -264,7 +264,7 @@ describe('convert packet to external one', () => {
       .setRouting(rounting)
       .setTimestamp(protoTimestamp());
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isEmotion()).toEqual(false);
@@ -286,7 +286,7 @@ describe('convert packet to external one', () => {
         .setRouting(new Routing().setSource(new Actor()).setTarget(new Actor()))
         .setTimestamp(protoTimestamp(today));
 
-      const result = EventFactory.fromProto(packet);
+      const result = InworldPacket.fromProto(packet);
 
       expect(result).toBeInstanceOf(InworldPacket);
       expect(result.isControl()).toEqual(true);
@@ -303,7 +303,7 @@ describe('convert packet to external one', () => {
         .setRouting(new Routing().setSource(new Actor()).setTarget(new Actor()))
         .setTimestamp(protoTimestamp(today));
 
-      const result = EventFactory.fromProto(packet);
+      const result = InworldPacket.fromProto(packet);
 
       expect(result).toBeInstanceOf(InworldPacket);
       expect(result.isControl()).toEqual(true);

--- a/__tests__/services/connection.service.spec.ts
+++ b/__tests__/services/connection.service.spec.ts
@@ -10,6 +10,7 @@ import { LoadSceneResponse } from '@proto/world-engine_pb';
 import { v4 } from 'uuid';
 
 import { protoTimestamp } from '../../src/common/helpers';
+import { InworldPacket } from '../../src/entities/inworld_packet.entity';
 import { Scene } from '../../src/entities/scene.entity';
 import { Session } from '../../src/entities/session.entity';
 import { SessionToken } from '../../src/entities/session_token.entity';
@@ -688,7 +689,7 @@ describe('message', () => {
     stream.emit('data', packet);
 
     expect(onMessage).toHaveBeenCalledTimes(1);
-    expect(onMessage).toHaveBeenCalledWith(EventFactory.fromProto(packet));
+    expect(onMessage).toHaveBeenCalledWith(InworldPacket.fromProto(packet));
   });
 });
 

--- a/__tests__/services/grpc/world_engine_client_grpc.service.spec.ts
+++ b/__tests__/services/grpc/world_engine_client_grpc.service.spec.ts
@@ -14,7 +14,13 @@ import { v4 } from 'uuid';
 import { Config } from '../../../src/common/config';
 import { CLIENT_ID } from '../../../src/common/constants';
 import { WorldEngineClientGrpcService } from '../../../src/services/gprc/world_engine_client_grpc.service';
-import { createAgent, sessionToken, user } from '../../helpers';
+import {
+  createAgent,
+  extension,
+  sessionContinuation,
+  sessionToken,
+  user,
+} from '../../helpers';
 const SCENE = v4();
 
 const agents = [createAgent(), createAgent()];
@@ -118,6 +124,27 @@ describe('load scene', () => {
     });
 
     expect(mockLoadScene.mock.calls[0][0].getClient()).toEqual(sceneClient);
+  });
+
+  test('should use provided additional props', async () => {
+    jest
+      .spyOn(WorldEngineClient.prototype, 'loadScene')
+      .mockImplementationOnce(mockLoadScene);
+
+    const capabilities = new CapabilitiesRequest()
+      .setAnimations(true)
+      .setEmotions(true);
+
+    await client.loadScene({
+      name: SCENE,
+      capabilities,
+      sessionToken,
+      setLoadSceneProps: extension.setLoadSceneProps,
+    });
+
+    expect(mockLoadScene.mock.calls[0][0].getSessionContinuation()).toEqual(
+      sessionContinuation,
+    );
   });
 });
 

--- a/jest.config.json
+++ b/jest.config.json
@@ -5,5 +5,8 @@
     "@proto/(.*)": "<rootDir>/proto/$1",
     "@root/(.*)": "<rootDir>/$1"
   },
-  "modulePathIgnorePatterns": ["__tests__/helpers.ts"]
+  "modulePathIgnorePatterns": [
+    "__tests__/data_structures.ts",
+    "__tests__/helpers.ts"
+  ]
 }

--- a/src/auth/key_signature.ts
+++ b/src/auth/key_signature.ts
@@ -2,7 +2,7 @@ import { TokensService } from '@proto/ai/inworld/studio/v1alpha/tokens_grpc_pb';
 import * as crypto from 'crypto';
 import { HmacSHA256 } from 'crypto-js';
 
-import { ApiKey } from '../common/interfaces';
+import { ApiKey } from '../common/data_structures';
 
 export interface KeySignatureProps {
   host: string;

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -1,4 +1,5 @@
-import { CapabilitiesRequest } from '@proto/world-engine_pb';
+import { InworldPacket as ProtoPacket } from '@proto/packets_pb';
+import { CapabilitiesRequest, LoadSceneRequest } from '@proto/world-engine_pb';
 
 import { SessionToken } from '../entities/session_token.entity';
 
@@ -64,4 +65,10 @@ export enum ConnectionState {
   LOADED = 'LOADED',
   LOADING = 'LOADING',
   INACTIVE = 'INACTIVE',
+}
+
+export interface Extension<InworldPacketT> {
+  setCapabilities?: (request: CapabilitiesRequest) => CapabilitiesRequest;
+  setLoadSceneProps?: (request: LoadSceneRequest) => LoadSceneRequest;
+  convertPacketFromProto?: (proto: ProtoPacket) => InworldPacketT;
 }

--- a/src/entities/inworld_packet.entity.ts
+++ b/src/entities/inworld_packet.entity.ts
@@ -1,3 +1,12 @@
+import {
+  Actor as ProtoActor,
+  AdditionalPhonemeInfo as ProtoAdditionalPhonemeInfo,
+  ControlEvent as ProtoControlEvent,
+  DataChunk,
+  InworldPacket as ProtoPacket,
+} from '@proto/packets_pb';
+import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
+
 import { EmotionBehavior } from './emotion-behavior.entity';
 import { EmotionStrength } from './emotion-strength.entity';
 
@@ -94,18 +103,18 @@ export interface ControlEvent {
 export class InworldPacket {
   private type: InworldPacketType = InworldPacketType.UNKNOWN;
 
-  date: string;
-  packetId: PacketId;
-  routing: Routing;
+  readonly date: string;
+  readonly packetId: PacketId;
+  readonly routing: Routing;
 
   // Events
-  text: TextEvent;
-  audio: AudioEvent;
-  control: ControlEvent;
-  trigger: TriggerEvent;
-  emotions: EmotionEvent;
-  silence: SilenceEvent;
-  cancelResponses: CancelResponsesEvent;
+  readonly text: TextEvent;
+  readonly audio: AudioEvent;
+  readonly control: ControlEvent;
+  readonly trigger: TriggerEvent;
+  readonly emotions: EmotionEvent;
+  readonly silence: SilenceEvent;
+  readonly cancelResponses: CancelResponsesEvent;
 
   constructor(props: InworldPacketProps) {
     this.packetId = props.packetId;
@@ -175,5 +184,132 @@ export class InworldPacket {
 
   isCancelResponse() {
     return this.type === InworldPacketType.CANCEL_RESPONSE;
+  }
+
+  static fromProto(proto: ProtoPacket): InworldPacket {
+    const packetId = proto.getPacketId();
+    const routing = proto.getRouting();
+    const source = routing.getSource();
+    const target = routing.getTarget();
+    const type = this.getType(proto);
+
+    const textEvent = proto.getText();
+    const emotionEvent = proto.getEmotion();
+    const additionalPhonemeInfo =
+      proto.getDataChunk()?.getAdditionalPhonemeInfoList() ?? [];
+
+    return new InworldPacket({
+      type,
+      date: proto.getTimestamp().toDate().toISOString(),
+      packetId: {
+        packetId: packetId.getPacketId(),
+        utteranceId: packetId.getUtteranceId(),
+        interactionId: packetId.getInteractionId(),
+      },
+      routing: {
+        source: {
+          name: source.getName(),
+          isPlayer: source.getType() === ProtoActor.Type.PLAYER,
+          isCharacter: source.getType() === ProtoActor.Type.AGENT,
+        },
+        target: {
+          name: target.getName(),
+          isPlayer: target.getType() === ProtoActor.Type.PLAYER,
+          isCharacter: target.getType() === ProtoActor.Type.AGENT,
+        },
+      },
+      ...(type === InworldPacketType.TRIGGER && {
+        trigger: {
+          name: proto.getCustom().getName(),
+          parameters: proto
+            .getCustom()
+            .getParametersList()
+            .map((p) => ({
+              name: p.getName(),
+              value: p.getValue(),
+            })),
+        },
+      }),
+      ...(type === InworldPacketType.TEXT && {
+        text: {
+          text: textEvent.getText(),
+          final: textEvent.getFinal(),
+        },
+      }),
+      ...(type === InworldPacketType.AUDIO && {
+        audio: {
+          chunk: proto.getDataChunk().getChunk_asB64(),
+          additionalPhonemeInfo: additionalPhonemeInfo.map(
+            (info: ProtoAdditionalPhonemeInfo) =>
+              ({
+                phoneme: info.getPhoneme(),
+                startOffsetS: this.durationToSeconds(info.getStartOffset()),
+              } as AdditionalPhonemeInfo),
+          ),
+        },
+      }),
+      ...(type === InworldPacketType.CONTROL && {
+        control: {
+          type: this.getControlType(proto),
+        },
+      }),
+      ...(type === InworldPacketType.SILENCE && {
+        silence: {
+          durationMs: proto.getDataChunk().getDurationMs(),
+        },
+      }),
+      ...(type === InworldPacketType.EMOTION && {
+        emotions: {
+          behavior: new EmotionBehavior(
+            EmotionBehavior.fromProto(emotionEvent.getBehavior()),
+          ),
+          strength: new EmotionStrength(
+            EmotionStrength.fromProto(emotionEvent.getStrength()),
+          ),
+        },
+      }),
+      ...(type === InworldPacketType.CANCEL_RESPONSE && {
+        cancelResponses: {
+          interactionId: proto.getCancelresponses().getInteractionId(),
+          utteranceId: proto.getCancelresponses().getUtteranceIdList(),
+        },
+      }),
+    });
+  }
+
+  private static getType(packet: ProtoPacket) {
+    switch (true) {
+      case packet.hasText():
+        return InworldPacketType.TEXT;
+      case packet.hasDataChunk() &&
+        packet.getDataChunk().getType() === DataChunk.DataType.AUDIO:
+        return InworldPacketType.AUDIO;
+      case packet.hasDataChunk() &&
+        packet.getDataChunk().getType() === DataChunk.DataType.SILENCE:
+        return InworldPacketType.SILENCE;
+      case packet.hasCustom():
+        return InworldPacketType.TRIGGER;
+      case packet.hasControl():
+        return InworldPacketType.CONTROL;
+      case packet.hasEmotion():
+        return InworldPacketType.EMOTION;
+      case packet.hasCancelresponses():
+        return InworldPacketType.CANCEL_RESPONSE;
+      default:
+        return InworldPacketType.UNKNOWN;
+    }
+  }
+
+  private static getControlType(packet: ProtoPacket) {
+    switch (packet.getControl().getAction()) {
+      case ProtoControlEvent.Action.INTERACTION_END:
+        return InworlControlType.INTERACTION_END;
+      default:
+        return InworlControlType.UNKNOWN;
+    }
+  }
+
+  private static durationToSeconds(duration: Duration) {
+    return duration.getSeconds() + duration.getNanos() / 1000000000;
   }
 }

--- a/src/entities/session_token.entity.ts
+++ b/src/entities/session_token.entity.ts
@@ -2,7 +2,7 @@ import util = require('node:util');
 
 import { SessionAccessToken } from '@proto/ai/inworld/studio/v1alpha/tokens_pb';
 
-import { SessionTokenProps } from '../common/interfaces';
+import { SessionTokenProps } from '../common/data_structures';
 
 const TIME_DIFF_MS = 50 * 60 * 1000; // 5 minutes
 

--- a/src/factories/event.ts
+++ b/src/factories/event.ts
@@ -1,6 +1,5 @@
 import {
   Actor,
-  AdditionalPhonemeInfo as ProtoAdditionalPhonemeInfo,
   CancelResponsesEvent,
   ControlEvent,
   CustomEvent,
@@ -10,21 +9,12 @@ import {
   Routing,
   TextEvent,
 } from '@proto/packets_pb';
-import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import { v4 } from 'uuid';
 
+import { CancelResponsesProps } from '../common/data_structures';
 import { protoTimestamp } from '../common/helpers';
-import { CancelResponsesProps } from '../common/interfaces';
 import { Character } from '../entities/character.entity';
-import { EmotionBehavior } from '../entities/emotion-behavior.entity';
-import { EmotionStrength } from '../entities/emotion-strength.entity';
-import {
-  AdditionalPhonemeInfo,
-  InworlControlType,
-  InworldPacket,
-  InworldPacketType,
-  TriggerParameter,
-} from '../entities/inworld_packet.entity';
+import { TriggerParameter } from '../entities/inworld_packet.entity';
 
 export class EventFactory {
   private character: Character = null;
@@ -40,7 +30,10 @@ export class EventFactory {
   dataChunk(chunk: string, type: DataChunk.DataType): ProtoPacket {
     const event = new DataChunk().setType(type).setChunk(chunk);
 
-    return this.protoPacket().setDataChunk(event);
+    return this.baseProtoPacket({
+      utteranceId: false,
+      interactionId: false,
+    }).setDataChunk(event);
   }
 
   audioSessionStart(): ProtoPacket {
@@ -48,7 +41,10 @@ export class EventFactory {
       ControlEvent.Action.AUDIO_SESSION_START,
     );
 
-    return this.protoPacket().setControl(event);
+    return this.baseProtoPacket({
+      utteranceId: false,
+      interactionId: false,
+    }).setControl(event);
   }
 
   audioSessionEnd(): ProtoPacket {
@@ -56,7 +52,10 @@ export class EventFactory {
       ControlEvent.Action.AUDIO_SESSION_END,
     );
 
-    return this.protoPacket().setControl(event);
+    return this.baseProtoPacket({
+      utteranceId: false,
+      interactionId: false,
+    }).setControl(event);
   }
 
   text(text: string): ProtoPacket {
@@ -64,9 +63,8 @@ export class EventFactory {
       .setText(text)
       .setSourceType(TextEvent.SourceType.TYPED_IN)
       .setFinal(true);
-    const packet = this.packet().setUtteranceId(v4()).setInteractionId(v4());
 
-    return this.protoPacket().setPacketId(packet).setText(event);
+    return this.baseProtoPacket().setText(event);
   }
 
   trigger(name: string, parameters: TriggerParameter[] = []): ProtoPacket {
@@ -80,9 +78,7 @@ export class EventFactory {
       );
     }
 
-    const packet = this.packet().setUtteranceId(v4()).setInteractionId(v4());
-
-    return this.protoPacket().setCustom(event).setPacketId(packet);
+    return this.baseProtoPacket().setCustom(event);
   }
 
   cancelResponse(cancelResponses?: CancelResponsesProps): ProtoPacket {
@@ -96,103 +92,25 @@ export class EventFactory {
       event.setUtteranceIdList(cancelResponses.utteranceId);
     }
 
-    return this.protoPacket().setCancelresponses(event);
+    return this.baseProtoPacket({
+      utteranceId: false,
+      interactionId: false,
+    }).setCancelresponses(event);
   }
 
-  static fromProto(proto: ProtoPacket): InworldPacket {
-    const packetId = proto.getPacketId();
-    const routing = proto.getRouting();
-    const source = routing.getSource();
-    const target = routing.getTarget();
-    const type = this.getType(proto);
+  baseProtoPacket(props?: { utteranceId?: boolean; interactionId?: boolean }) {
+    const packetId = new PacketId().setPacketId(v4());
 
-    const textEvent = proto.getText();
-    const emotionEvent = proto.getEmotion();
-    const additionalPhonemeInfo =
-      proto.getDataChunk()?.getAdditionalPhonemeInfoList() ?? [];
+    if (props?.utteranceId !== false) {
+      packetId.setUtteranceId(v4());
+    }
 
-    return new InworldPacket({
-      type,
-      date: proto.getTimestamp().toDate().toISOString(),
-      packetId: {
-        packetId: packetId.getPacketId(),
-        utteranceId: packetId.getUtteranceId(),
-        interactionId: packetId.getInteractionId(),
-      },
-      routing: {
-        source: {
-          name: source.getName(),
-          isPlayer: source.getType() === Actor.Type.PLAYER,
-          isCharacter: source.getType() === Actor.Type.AGENT,
-        },
-        target: {
-          name: target.getName(),
-          isPlayer: target.getType() === Actor.Type.PLAYER,
-          isCharacter: target.getType() === Actor.Type.AGENT,
-        },
-      },
-      ...(type === InworldPacketType.TRIGGER && {
-        trigger: {
-          name: proto.getCustom().getName(),
-          parameters: proto
-            .getCustom()
-            .getParametersList()
-            .map((p) => ({
-              name: p.getName(),
-              value: p.getValue(),
-            })),
-        },
-      }),
-      ...(type === InworldPacketType.TEXT && {
-        text: {
-          text: textEvent.getText(),
-          final: textEvent.getFinal(),
-        },
-      }),
-      ...(type === InworldPacketType.AUDIO && {
-        audio: {
-          chunk: proto.getDataChunk().getChunk_asB64(),
-          additionalPhonemeInfo: additionalPhonemeInfo.map(
-            (info: ProtoAdditionalPhonemeInfo) =>
-              ({
-                phoneme: info.getPhoneme(),
-                startOffsetS: this.durationToSeconds(info.getStartOffset()),
-              } as AdditionalPhonemeInfo),
-          ),
-        },
-      }),
-      ...(type === InworldPacketType.CONTROL && {
-        control: {
-          type: this.getControlType(proto),
-        },
-      }),
-      ...(type === InworldPacketType.SILENCE && {
-        silence: {
-          durationMs: proto.getDataChunk().getDurationMs(),
-        },
-      }),
-      ...(type === InworldPacketType.EMOTION && {
-        emotions: {
-          behavior: new EmotionBehavior(
-            EmotionBehavior.fromProto(emotionEvent.getBehavior()),
-          ),
-          strength: new EmotionStrength(
-            EmotionStrength.fromProto(emotionEvent.getStrength()),
-          ),
-        },
-      }),
-      ...(type === InworldPacketType.CANCEL_RESPONSE && {
-        cancelResponses: {
-          interactionId: proto.getCancelresponses().getInteractionId(),
-          utteranceId: proto.getCancelresponses().getUtteranceIdList(),
-        },
-      }),
-    });
-  }
+    if (props?.interactionId !== false) {
+      packetId.setInteractionId(v4());
+    }
 
-  private protoPacket(): ProtoPacket {
     return new ProtoPacket()
-      .setPacketId(this.packet())
+      .setPacketId(packetId)
       .setRouting(this.routing())
       .setTimestamp(protoTimestamp());
   }
@@ -205,45 +123,5 @@ export class EventFactory {
       .setName(this.character?.id);
 
     return new Routing().setSource(source).setTarget(target);
-  }
-
-  private packet(): PacketId {
-    return new PacketId().setPacketId(v4());
-  }
-
-  private static getType(packet: ProtoPacket) {
-    switch (true) {
-      case packet.hasText():
-        return InworldPacketType.TEXT;
-      case packet.hasDataChunk() &&
-        packet.getDataChunk().getType() === DataChunk.DataType.AUDIO:
-        return InworldPacketType.AUDIO;
-      case packet.hasDataChunk() &&
-        packet.getDataChunk().getType() === DataChunk.DataType.SILENCE:
-        return InworldPacketType.SILENCE;
-      case packet.hasCustom():
-        return InworldPacketType.TRIGGER;
-      case packet.hasControl():
-        return InworldPacketType.CONTROL;
-      case packet.hasEmotion():
-        return InworldPacketType.EMOTION;
-      case packet.hasCancelresponses():
-        return InworldPacketType.CANCEL_RESPONSE;
-      default:
-        return InworldPacketType.UNKNOWN;
-    }
-  }
-
-  private static getControlType(packet: ProtoPacket) {
-    switch (packet.getControl().getAction()) {
-      case ControlEvent.Action.INTERACTION_END:
-        return InworlControlType.INTERACTION_END;
-      default:
-        return InworlControlType.UNKNOWN;
-    }
-  }
-
-  private static durationToSeconds(duration: Duration) {
-    return duration.getSeconds() + duration.getNanos() / 1000000000;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import {
   ConnectionConfig,
   SessionTokenProps,
   User,
-} from './common/interfaces';
+} from './common/data_structures';
 import { Character } from './entities/character.entity';
 import {
   EmotionBehavior,

--- a/src/services/gprc/token_client_grpc.service.ts
+++ b/src/services/gprc/token_client_grpc.service.ts
@@ -8,8 +8,8 @@ import { promisify } from 'util';
 
 import { KeySignature } from '../../auth/key_signature';
 import { Config } from '../../common/config';
+import { ApiKey } from '../../common/data_structures';
 import { grpcOptions } from '../../common/helpers';
-import { ApiKey } from '../../common/interfaces';
 
 export class TokenClientGrpcService {
   private readonly config = Config.getInstance();

--- a/src/services/inworld_connection.service.ts
+++ b/src/services/inworld_connection.service.ts
@@ -1,14 +1,19 @@
-import { DataChunk } from '@proto/packets_pb';
+import { DataChunk, InworldPacket as ProtoPacket } from '@proto/packets_pb';
 
-import { CancelResponsesProps } from '../common/interfaces';
+import { CancelResponsesProps } from '../common/data_structures';
 import { Character } from '../entities/character.entity';
-import { TriggerParameter } from '../entities/inworld_packet.entity';
+import {
+  InworldPacket,
+  TriggerParameter,
+} from '../entities/inworld_packet.entity';
 import { ConnectionService } from './connection.service';
 
-export class InworldConnectionService {
-  private connection: ConnectionService;
+export class InworldConnectionService<
+  InworldPacketT extends InworldPacket = InworldPacket,
+> {
+  private connection: ConnectionService<InworldPacketT>;
 
-  constructor(connection: ConnectionService) {
+  constructor(connection: ConnectionService<InworldPacketT>) {
     this.connection = connection;
   }
 
@@ -74,5 +79,13 @@ export class InworldConnectionService {
     return this.connection.send(() =>
       this.connection.getEventFactory().cancelResponse(cancelResponses),
     );
+  }
+
+  async sendCustomPacket(getPacket: () => ProtoPacket) {
+    return this.connection.send(() => getPacket());
+  }
+
+  baseProtoPacket(props?: { utteranceId?: boolean; interactionId?: boolean }) {
+    return this.connection.getEventFactory().baseProtoPacket(props);
   }
 }


### PR DESCRIPTION
Attempt to test Prev Dialog (https://github.com/inworld-ai/inworld-nodejs-sdk/pull/19/files) before expose it to DSL

```
interface RegenerateResponse {
  interactionId?: string;
}

MutationEvent {
  regenerateResponse?: RegenerateResponse;
}

interface ExtendedInworldPacket extends InworldPacket {
  mutation: MutationEvent;
}

const previousDialog = new PreviousDialog().setPhrasesList([
  new PreviousDialog.Phrase()
    .setPhrase(v4())
    .setTalker(PreviousDialog.DialogParticipant.CHARACTER),
  new PreviousDialog.Phrase()
    .setPhrase(v4())
    .setTalker(PreviousDialog.DialogParticipant.PLAYER),
]);

export const sessionContinuation = new SessionContinuation().setPreviousDialog(
  previousDialog,
);

const client = new InworldClient<
  ExtendedInworldPacket
>()
  ...
  .setExtension({
    convertPacketFromProto: (proto: ProtoPacket) => {
      const packet = InworldPacket.fromProto(proto) as ExtendedInworldPacket;

      if (proto.getMutation()?.hasRegenerateResponse()) {
        const mutation = {
          regenerateResponse: {
            interactionId: proto
              .getMutation()
              .getRegenerateResponse()
              .getInteractionId(),
          },
        };
        packet.mutation = mutation;
      }

      return packet;
    },
    setCapabilities: (request: CapabilitiesRequest) => request.setRegenerateResponse(true),
    setLoadSceneProps: (request: LoadSceneRequest) => request.setSessionContinuation(sessionContinuation),
  });
```