### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add recognized text to upload audio file example
 * Added missed empty .env file to examples
 * Fixed update test audio file
+* Changed parameter from `name` to `scene` in `world_engine_client_grpc.service.generateSessionToken`
 * Remove deprecated method support for token, emotions, character and client
 
 

--- a/src/services/gprc/world_engine_client_grpc.service.ts
+++ b/src/services/gprc/world_engine_client_grpc.service.ts
@@ -48,11 +48,11 @@ export class WorldEngineClientGrpcService {
 
   public async generateSessionToken(
     apiKey: ApiKey,
-    name: string,
+    scene: string,
   ): Promise<AccessToken> {
     const metadata = new Metadata();
     const request = new GenerateTokenRequest();
-    const resource = `workspaces/${SCENE_PATTERN.exec(name)[1]}`;
+    const resource = `workspaces/${SCENE_PATTERN.exec(scene)[1]}`;
 
     request.setKey(apiKey.key);
     request.setResourcesList([resource]);


### PR DESCRIPTION
* fix: Changed parameter from name to scene in world_engine_client_grpc.service.generateSessionToken
* Added JS examples
* Added Say hello example
* Add recognized text to upload audio file example
* Added missed empty .env file to examples
* Fixed update test audio file
* Changed parameter from `name` to `scene` in `world_engine_client_grpc.service.generateSessionToken`
* Remove deprecated method support for token, emotions, character and client