### PR TITLE
Fix release push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
         run: git config --global user.email "github-service-account@inworld.ai" &&  git config --global user.name "CI-inworld"
       - name: Checkout source code
         uses: actions/checkout@v3
+        with:
+          ref: main
+          ssh-key: ${{ secrets.GH_SERVICE_ACCOUNT_SSH_KEY }}
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Description
Release action need to have permissions for push in main to bump package version

## Related Ticket (for Inworld.ai developers)
The same as https://github.com/inworld-ai/inworld-web-sdk/pull/61

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
