### PR TITLE
feat: Add opportunity to generate session token outside of SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- Add opportunity to generate session token outside of SDK
+
 ## [1.7.0] - 2023-09-01
 
 ### Added

--- a/__tests__/clients/inworld.client.spec.ts
+++ b/__tests__/clients/inworld.client.spec.ts
@@ -23,6 +23,7 @@ describe('should finish with success', () => {
   const onError = jest.fn();
   const onMessage = jest.fn();
   const onDisconnect = jest.fn();
+  const generateSessionTokenFn = jest.fn();
   const sessionGetterSetter = {
     get: jest.fn(),
     set: jest.fn(),
@@ -41,6 +42,7 @@ describe('should finish with success', () => {
       .setOnError(onError)
       .setOnSession(sessionGetterSetter)
       .setExtension(extension)
+      .setGenerateSessionToken(generateSessionTokenFn)
       .setSessionContinuation({ previousDialog: phrases });
   });
 

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -103,6 +103,12 @@ export class InworldClient<
     return this;
   }
 
+  setGenerateSessionToken(generateSessionToken: GenerateSessionTokenFn) {
+    this.generateSessionTokenFn = generateSessionToken;
+
+    return this;
+  }
+
   setOnSession(props: GetterSetter<Session>) {
     this.sessionGetterSetter = props;
 


### PR DESCRIPTION
## Description

Revert back method `setGenerateSessionToken`

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3849

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
