### PR TITLE
Generate proto packet just once to dispatching it to the bidirectional stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add opportunity to generate session token outside of SDK
 - Add `correlationId` to text, custom and cancel response packets
 
+### Fixed
+
+- Generate proto packet just once to dispatching it to the bidirectional stream
+
 ## [1.7.0] - 2023-09-01
 
 ### Added

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -198,3 +198,11 @@ export const phrases = [
   },
 ];
 export const previousDialog = new PreviousDialog(phrases);
+
+export const setTimeoutMock = (callback: any) => {
+  if (typeof callback === 'function') {
+    callback();
+  }
+
+  return { hasRef: () => false } as NodeJS.Timeout;
+};

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -37,9 +37,9 @@ interface ConnectionProps<InworldPacketT> {
   extension?: Extension<InworldPacketT>;
 }
 
-export interface QueueItem {
+interface QueueItem {
   getPacket: () => ProtoPacket;
-  afterWriting?: (packet: ProtoPacket) => void;
+  afterWriting: (packet: ProtoPacket) => void;
 }
 
 export class ConnectionService<
@@ -368,7 +368,7 @@ export class ConnectionService<
   private releaseQueue() {
     this.packetQueue.forEach((item: QueueItem) => {
       const protoPacket = this.writeToStream(item.getPacket);
-      item.afterWriting?.(protoPacket);
+      item.afterWriting(protoPacket);
     });
 
     this.packetQueue = [];

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -236,7 +236,7 @@ export class ConnectionService<
   private writeToStream(getPacket: () => ProtoPacket) {
     const packet = getPacket();
 
-    this.stream?.write(getPacket());
+    this.stream?.write(packet);
 
     this.logger.debug({
       action: 'Send packet',


### PR DESCRIPTION
## Description

- Generate proto packet just once to dispatching it to the bidirectional stream
-  Fix test running on node version >= 19

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3914
https://inworldai.atlassian.net/browse/CORE-3889

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
