### PR TITLE
Release 1.8.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,4 +16,5 @@ build/jest-result.json
 */**/yarn.lock
 */**/package-lock.json
 RELEASEME.md
+EXTENSIONS.md
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Add `correlationId` to text, custom and cancel response packets
 - Allow to use async `onDisconnect` and `onError`
 
+### Fixed
+
+- Generate proto packet just once to dispatching it to the bidirectional stream
+
 ## [1.7.0] - 2023-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- Add opportunity to generate session token outside of SDK
+
 ## [1.7.0] - 2023-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add opportunity to generate session token outside of SDK
 - Add `correlationId` to text, custom and cancel response packets
+- Allow to use async `onDisconnect` and `onError`
 
 ## [1.7.0] - 2023-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Add opportunity to generate session token outside of SDK
+- Add `correlationId` to text, custom and cancel response packets
 
 ## [1.7.0] - 2023-09-01
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,0 +1,102 @@
+# When Inworld AI Node.js SDK should be extended
+
+Certain features are not directly accessible through the Inworld AI Node.js SDK but are supported at the protocol level:
+
+1. Some features are exclusively used within [Studio](https://studio.inworld.ai), and it is reasonable to hide their implementation.
+1. Certain features are currently in the development phase and are not yet accessible on the production server from the backend. Nevertheless, it is necessary to test them before introducing new methods into DSL.
+
+
+# How to extend Inworld AI Node.js SDK
+
+Here are several ways to enhance the functionality of the Inworld AI Node.js SDK:
+
+1. Extending the [Load Scene Request](#extend-load-scene-request). For example, it's possible to add additional capabilities.
+1. Manual Parsing of [Load Scene Response](#parse-load-scene-response). For example, parse the load scene response to retrieve previous state packets and render them as part of conversation history.
+1. Sending [Custom Packets](#send-custom-packet) (ensure you provide any necessary additional capabilities).
+
+
+## Extend load scene request
+
+```ts
+  const beforeLoadScene = (request) => {
+    const capabilities = new CapabilitiesRequest()
+      .setAudio(true)
+      .setText(true)
+      .setRegenerateResponse(true);
+    request.setCapabilities(capabilities);
+
+    return request;
+  };
+
+  const client = new InworldClient()
+    .setConfiguration({ capabilities })
+    .setUser(user)
+    .setScene(sceneName)
+    ...
+    .setExtension({ beforeLoadScene });
+
+  this.connection = client.build();
+```
+
+## Parse load scene response
+
+```ts
+  const afterLoadScene = (response) => {
+    // Do something with response.
+    console.log(response.getPreviousState()?.getStateHoldersList());
+  };
+  const client = new InworldClient()
+    .setConfiguration({ capabilities })
+    .setUser(user)
+    .setScene(sceneName)
+    ...
+    .setExtension({ afterLoadScene });
+
+  this.connection = client.build();
+```
+
+## Send custom packet
+
+```ts
+  interface ExtendedInworldPacket extends InworldPacket {
+    isRegenerateResponse: boolean;
+  }
+
+  const sendRegenerateResponse = (interactionId?: string) => {
+    const customPacket = this.connection.baseProtoPacket();
+    const mutation = new MutationEvent().setRegenerateResponse(
+      new RegenerateResponse().setInteractionId(interactionId ?? uuid()),
+    );
+
+    customPacket.setMutation(mutation);
+    customPacket.getPacketId().setCorrelationId(correlationId);
+
+    return customPacket;
+  };
+
+  const convertPacketFromProto = (proto) => {
+    const packet = InworldPacket.fromProto(
+      proto,
+    ) as ExtendedInworldPacket;
+
+    packet.isRegenerateResponse = true;
+
+    return packet;
+  };
+
+  const interactionId = 'some-interaction-id';
+  const client = new InworldClient<ExtendedInworldPacket>()
+    .setConfiguration({ capabilities })
+    .setUser(user)
+    .setScene(sceneName)
+    ...
+    .setExtension({
+      convertPacketFromProto,
+      // See ## Extend load scene request
+      beforeLoadScene,
+    });
+
+  this.connection = client.build();
+
+  this.connection.sendCustomPacket(() => sendRegenerateResponse(interactionId));
+```

--- a/__tests__/clients/inworld.client.spec.ts
+++ b/__tests__/clients/inworld.client.spec.ts
@@ -23,6 +23,7 @@ describe('should finish with success', () => {
   const onError = jest.fn();
   const onMessage = jest.fn();
   const onDisconnect = jest.fn();
+  const generateSessionTokenFn = jest.fn();
   const sessionGetterSetter = {
     get: jest.fn(),
     set: jest.fn(),
@@ -41,6 +42,7 @@ describe('should finish with success', () => {
       .setOnError(onError)
       .setOnSession(sessionGetterSetter)
       .setExtension(extension)
+      .setGenerateSessionToken(generateSessionTokenFn)
       .setSessionContinuation({ previousDialog: phrases });
   });
 

--- a/__tests__/entities/inworld_packet.entity.spec.ts
+++ b/__tests__/entities/inworld_packet.entity.spec.ts
@@ -15,6 +15,10 @@ const packetId: PacketId = {
   interactionId: v4(),
   utteranceId: v4(),
 };
+const packetIdWithCorrelation = {
+  ...packetId,
+  correlationId: v4(),
+};
 const routing: Routing = {
   source: {
     name: v4(),
@@ -57,7 +61,7 @@ test('should get text packet fields', () => {
 
   const packet = new InworldPacket({
     text,
-    packetId,
+    packetId: packetIdWithCorrelation,
     routing,
     date,
     type: InworldPacketType.TEXT,
@@ -67,12 +71,12 @@ test('should get text packet fields', () => {
   expect(packet.text).toEqual(text);
   expect(packet.routing).toEqual(routing);
   expect(packet.date).toEqual(date);
-  expect(packet.packetId).toEqual(packetId);
+  expect(packet.packetId).toEqual(packetIdWithCorrelation);
 });
 
 test('should get trigger packet fields', () => {
   const packet = new InworldPacket({
-    packetId,
+    packetId: packetIdWithCorrelation,
     routing,
     date,
     type: InworldPacketType.TRIGGER,
@@ -81,7 +85,7 @@ test('should get trigger packet fields', () => {
   expect(packet.isTrigger()).toEqual(true);
   expect(packet.routing).toEqual(routing);
   expect(packet.date).toEqual(date);
-  expect(packet.packetId).toEqual(packetId);
+  expect(packet.packetId).toEqual(packetIdWithCorrelation);
 });
 
 test('should get emotion packet fields', () => {

--- a/__tests__/factories/event.spec.ts
+++ b/__tests__/factories/event.spec.ts
@@ -45,11 +45,15 @@ describe('event types', () => {
   test('should generate audio event', () => {
     const chunk = v4();
     const event = factory.dataChunk(chunk, DataChunk.DataType.AUDIO);
+    const packetId = event.getPacketId();
 
     expect(event.hasDataChunk()).toEqual(true);
     expect(event.getDataChunk().getChunk()).toEqual(chunk);
     expect(event.getDataChunk().getType()).toEqual(DataChunk.DataType.AUDIO);
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeFalsy();
+    expect(packetId.getUtteranceId()).toBeFalsy();
+    expect(packetId.getCorrelationId()).toBeFalsy();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -57,12 +61,16 @@ describe('event types', () => {
 
   test('should generate audio session start', () => {
     const event = factory.audioSessionStart();
+    const packetId = event.getPacketId();
 
     expect(event.hasControl()).toEqual(true);
     expect(event.getControl().getAction()).toEqual(
       ControlEvent.Action.AUDIO_SESSION_START,
     );
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeFalsy();
+    expect(packetId.getUtteranceId()).toBeFalsy();
+    expect(packetId.getCorrelationId()).toBeFalsy();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -70,12 +78,16 @@ describe('event types', () => {
 
   test('should generate audio session end', () => {
     const event = factory.audioSessionEnd();
+    const packetId = event.getPacketId();
 
     expect(event.hasControl()).toEqual(true);
     expect(event.getControl().getAction()).toEqual(
       ControlEvent.Action.AUDIO_SESSION_END,
     );
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeFalsy();
+    expect(packetId.getUtteranceId()).toBeFalsy();
+    expect(packetId.getCorrelationId()).toBeFalsy();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -83,12 +95,16 @@ describe('event types', () => {
 
   test('should generate mute', () => {
     const event = factory.mutePlayback(true);
+    const packetId = event.getPacketId();
 
     expect(event.hasControl()).toEqual(true);
     expect(event.getControl().getAction()).toEqual(
       ControlEvent.Action.TTS_PLAYBACK_MUTE,
     );
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeFalsy();
+    expect(packetId.getUtteranceId()).toBeFalsy();
+    expect(packetId.getCorrelationId()).toBeFalsy();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -96,12 +112,16 @@ describe('event types', () => {
 
   test('should generate unmute', () => {
     const event = factory.mutePlayback(false);
+    const packetId = event.getPacketId();
 
     expect(event.hasControl()).toEqual(true);
     expect(event.getControl().getAction()).toEqual(
       ControlEvent.Action.TTS_PLAYBACK_UNMUTE,
     );
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeFalsy();
+    expect(packetId.getUtteranceId()).toBeFalsy();
+    expect(packetId.getCorrelationId()).toBeFalsy();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -110,10 +130,14 @@ describe('event types', () => {
   test('should generate text event', () => {
     const text = v4();
     const event = factory.text(text);
+    const packetId = event.getPacketId();
 
     expect(event.hasText()).toEqual(true);
     expect(event.getText().getText()).toEqual(text);
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeDefined();
+    expect(packetId.getUtteranceId()).toBeDefined();
+    expect(packetId.getCorrelationId()).toBeDefined();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -122,11 +146,15 @@ describe('event types', () => {
   test('should generate trigger event without parameters', () => {
     const name = v4();
     const event = factory.trigger(name);
+    const packetId = event.getPacketId();
 
     expect(event.hasCustom()).toEqual(true);
     expect(event.getCustom().getName()).toEqual(name);
     expect(event.getCustom().getParametersList()).toEqual([]);
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeDefined();
+    expect(packetId.getUtteranceId()).toBeDefined();
+    expect(packetId.getCorrelationId()).toBeDefined();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -136,6 +164,7 @@ describe('event types', () => {
     const name = v4();
     const parameters = [{ name: v4(), value: v4() }];
     const event = factory.trigger(name, parameters);
+    const packetId = event.getPacketId();
 
     expect(event.hasCustom()).toEqual(true);
     expect(event.getCustom().getName()).toEqual(name);
@@ -145,19 +174,10 @@ describe('event types', () => {
     expect(event.getCustom().getParametersList()[0].getValue()).toEqual(
       parameters[0].value,
     );
-    expect(event.hasPacketId()).toEqual(true);
-    expect(event.hasRouting()).toEqual(true);
-    expect(event.getRouting().getTarget().getName()).toEqual(character.id);
-    expect(event.hasTimestamp()).toEqual(true);
-  });
-
-  test('should generate trigger event', () => {
-    const name = v4();
-    const event = factory.trigger(name);
-
-    expect(event.hasCustom()).toEqual(true);
-    expect(event.getCustom().getName()).toEqual(name);
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeDefined();
+    expect(packetId.getUtteranceId()).toBeDefined();
+    expect(packetId.getCorrelationId()).toBeDefined();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -165,9 +185,13 @@ describe('event types', () => {
 
   test('should generate cancel response event for all answers', () => {
     const event = factory.cancelResponse();
+    const packetId = event.getPacketId();
 
     expect(event.getMutation().hasCancelResponses()).toEqual(true);
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeDefined();
+    expect(packetId.getUtteranceId()).toBeDefined();
+    expect(packetId.getCorrelationId()).toBeDefined();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -180,6 +204,7 @@ describe('event types', () => {
     };
     const event = factory.cancelResponse(props);
     const mutation = event.getMutation();
+    const packetId = event.getPacketId();
 
     expect(mutation.hasCancelResponses()).toEqual(true);
     expect(mutation.getCancelResponses().getInteractionId()).toEqual(
@@ -188,7 +213,10 @@ describe('event types', () => {
     expect(mutation.getCancelResponses().getUtteranceIdList()).toEqual(
       props.utteranceId,
     );
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeDefined();
+    expect(packetId.getUtteranceId()).toBeDefined();
+    expect(packetId.getCorrelationId()).toBeDefined();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual(character.id);
     expect(event.hasTimestamp()).toEqual(true);
@@ -197,9 +225,13 @@ describe('event types', () => {
   test('should not use character id if character is not set', () => {
     factory.setCurrentCharacter(null);
     const event = factory.cancelResponse();
+    const packetId = event.getPacketId();
 
     expect(event.getMutation().hasCancelResponses()).toEqual(true);
-    expect(event.hasPacketId()).toEqual(true);
+    expect(packetId.getPacketId()).toBeDefined();
+    expect(packetId.getInteractionId()).toBeDefined();
+    expect(packetId.getUtteranceId()).toBeDefined();
+    expect(packetId.getCorrelationId()).toBeDefined();
     expect(event.hasRouting()).toEqual(true);
     expect(event.getRouting().getTarget().getName()).toEqual('');
     expect(event.hasTimestamp()).toEqual(true);

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -198,3 +198,11 @@ export const phrases = [
   },
 ];
 export const previousDialog = new PreviousDialog(phrases);
+
+export const setTimeoutMock = (callback: any) => {
+  if (typeof callback === 'function') {
+    callback();
+  }
+
+  return { hasRef: () => false } as NodeJS.Timeout;
+};

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -37,8 +37,8 @@ export class InworldClient<
   private generateSessionTokenFn: GenerateSessionTokenFn;
   private sessionGetterSetter: GetterSetter<Session>;
 
-  private onDisconnect: (() => void) | undefined;
-  private onError: ((err: ServiceError) => void) | undefined;
+  private onDisconnect: (() => Awaitable<void>) | undefined;
+  private onError: ((err: ServiceError) => Awaitable<void>) | undefined;
   private onMessage: ((message: InworldPacketT) => Awaitable<void>) | undefined;
 
   private extension: Extension<InworldPacketT>;
@@ -82,16 +82,16 @@ export class InworldClient<
     return this;
   }
 
-  setOnDisconnect(fn: () => void) {
+  setOnDisconnect(fn: () => Awaitable<void>) {
     this.onDisconnect = fn;
 
     return this;
   }
 
-  setOnError(fn: (err: ServiceError) => void) {
-    this.onError = (err: ServiceError) => {
+  setOnError(fn: (err: ServiceError) => Awaitable<void>) {
+    this.onError = async (err: ServiceError) => {
       this.logError(err);
-      fn(err);
+      await fn(err);
     };
 
     return this;

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -103,6 +103,12 @@ export class InworldClient<
     return this;
   }
 
+  setGenerateSessionToken(generateSessionToken: GenerateSessionTokenFn) {
+    this.generateSessionTokenFn = generateSessionToken;
+
+    return this;
+  }
+
   setOnSession(props: GetterSetter<Session>) {
     this.sessionGetterSetter = props;
 

--- a/src/entities/inworld_packet.entity.ts
+++ b/src/entities/inworld_packet.entity.ts
@@ -46,6 +46,7 @@ export interface PacketId {
   packetId: string;
   utteranceId: string;
   interactionId: string;
+  correlationId?: string;
 }
 
 export interface EmotionEvent {
@@ -221,6 +222,7 @@ export class InworldPacket {
         packetId: packetId.getPacketId(),
         utteranceId: packetId.getUtteranceId(),
         interactionId: packetId.getInteractionId(),
+        correlationId: packetId.getCorrelationId(),
       },
       routing: {
         source: {

--- a/src/factories/event.ts
+++ b/src/factories/event.ts
@@ -78,7 +78,7 @@ export class EventFactory {
       .setSourceType(TextEvent.SourceType.TYPED_IN)
       .setFinal(true);
 
-    return this.baseProtoPacket().setText(event);
+    return this.baseProtoPacket({ correlationId: true }).setText(event);
   }
 
   trigger(name: string, parameters: TriggerParameter[] = []): ProtoPacket {
@@ -92,7 +92,7 @@ export class EventFactory {
       );
     }
 
-    return this.baseProtoPacket().setCustom(event);
+    return this.baseProtoPacket({ correlationId: true }).setCustom(event);
   }
 
   cancelResponse(cancelResponses?: CancelResponsesProps): ProtoPacket {
@@ -109,10 +109,15 @@ export class EventFactory {
     return this.baseProtoPacket({
       utteranceId: false,
       interactionId: false,
+      correlationId: true,
     }).setMutation(new MutationEvent().setCancelResponses(event));
   }
 
-  baseProtoPacket(props?: { utteranceId?: boolean; interactionId?: boolean }) {
+  baseProtoPacket(props?: {
+    utteranceId?: boolean;
+    interactionId?: boolean;
+    correlationId?: boolean;
+  }) {
     const packetId = new PacketId().setPacketId(v4());
 
     if (props?.utteranceId !== false) {
@@ -121,6 +126,10 @@ export class EventFactory {
 
     if (props?.interactionId !== false) {
       packetId.setInteractionId(v4());
+    }
+
+    if (props?.correlationId) {
+      packetId.setCorrelationId(v4());
     }
 
     return new ProtoPacket()

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -30,8 +30,8 @@ interface ConnectionProps<InworldPacketT> {
   config?: InternalClientConfiguration;
   sessionGetterSetter?: GetterSetter<Session>;
   sessionContinuation?: SessionContinuation;
-  onDisconnect?: () => void;
-  onError: (err: ServiceError) => void;
+  onDisconnect?: () => Awaitable<void>;
+  onError: (err: ServiceError) => Awaitable<void>;
   onMessage?: (message: InworldPacketT) => Awaitable<void>;
   generateSessionToken?: GenerateSessionTokenFn;
   extension?: Extension<InworldPacketT>;
@@ -61,8 +61,8 @@ export class ConnectionService<
 
   private engineService = new WorldEngineClientGrpcService<InworldPacketT>();
 
-  private onDisconnect: () => void;
-  private onError: (err: ServiceError) => void;
+  private onDisconnect: () => Awaitable<void>;
+  private onError: (err: ServiceError) => Awaitable<void>;
   private onMessage: ((message: ProtoPacket) => Awaitable<void>) | undefined;
 
   private logger = Logger.getInstance();
@@ -70,9 +70,9 @@ export class ConnectionService<
   constructor(props: ConnectionProps<InworldPacketT>) {
     this.connectionProps = props;
 
-    this.onDisconnect = () => {
+    this.onDisconnect = async () => {
       this.state = ConnectionState.INACTIVE;
-      this.connectionProps.onDisconnect?.();
+      await this.connectionProps.onDisconnect?.();
     };
     this.onError = this.connectionProps.onError;
 

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -37,9 +37,9 @@ interface ConnectionProps<InworldPacketT> {
   extension?: Extension<InworldPacketT>;
 }
 
-export interface QueueItem {
+interface QueueItem {
   getPacket: () => ProtoPacket;
-  afterWriting?: (packet: ProtoPacket) => void;
+  afterWriting: (packet: ProtoPacket) => void;
 }
 
 export class ConnectionService<
@@ -236,7 +236,7 @@ export class ConnectionService<
   private writeToStream(getPacket: () => ProtoPacket) {
     const packet = getPacket();
 
-    this.stream?.write(getPacket());
+    this.stream?.write(packet);
 
     this.logger.debug({
       action: 'Send packet',
@@ -368,7 +368,7 @@ export class ConnectionService<
   private releaseQueue() {
     this.packetQueue.forEach((item: QueueItem) => {
       const protoPacket = this.writeToStream(item.getPacket);
-      item.afterWriting?.(protoPacket);
+      item.afterWriting(protoPacket);
     });
 
     this.packetQueue = [];

--- a/src/services/gprc/world_engine_client_grpc.service.ts
+++ b/src/services/gprc/world_engine_client_grpc.service.ts
@@ -39,8 +39,8 @@ export interface LoadSceneProps<InworldPacketT> {
 }
 export interface SessionProps {
   sessionToken: SessionToken;
-  onDisconnect?: () => void;
-  onError?: (err: ServiceError) => void;
+  onDisconnect?: () => Awaitable<void>;
+  onError?: (err: ServiceError) => Awaitable<void>;
   onMessage?: (message: ProtoPacket) => Awaitable<void>;
 }
 


### PR DESCRIPTION
### Added

- Add opportunity to generate session token outside of SDK
- Add `correlationId` to text, custom and cancel response packets
- Allow to use async `onDisconnect` and `onError`

### Fixed

- Generate proto packet just once to dispatching it to the bidirectional stream