### PR TITLE
fix: Include the correlationId to fromProto conversion method

### DIFF
--- a/__tests__/entities/inworld_packet.entity.spec.ts
+++ b/__tests__/entities/inworld_packet.entity.spec.ts
@@ -15,6 +15,10 @@ const packetId: PacketId = {
   interactionId: v4(),
   utteranceId: v4(),
 };
+const packetIdWithCorrelation = {
+  ...packetId,
+  correlationId: v4(),
+};
 const routing: Routing = {
   source: {
     name: v4(),
@@ -57,7 +61,7 @@ test('should get text packet fields', () => {
 
   const packet = new InworldPacket({
     text,
-    packetId,
+    packetId: packetIdWithCorrelation,
     routing,
     date,
     type: InworldPacketType.TEXT,
@@ -67,12 +71,12 @@ test('should get text packet fields', () => {
   expect(packet.text).toEqual(text);
   expect(packet.routing).toEqual(routing);
   expect(packet.date).toEqual(date);
-  expect(packet.packetId).toEqual(packetId);
+  expect(packet.packetId).toEqual(packetIdWithCorrelation);
 });
 
 test('should get trigger packet fields', () => {
   const packet = new InworldPacket({
-    packetId,
+    packetId: packetIdWithCorrelation,
     routing,
     date,
     type: InworldPacketType.TRIGGER,
@@ -81,7 +85,7 @@ test('should get trigger packet fields', () => {
   expect(packet.isTrigger()).toEqual(true);
   expect(packet.routing).toEqual(routing);
   expect(packet.date).toEqual(date);
-  expect(packet.packetId).toEqual(packetId);
+  expect(packet.packetId).toEqual(packetIdWithCorrelation);
 });
 
 test('should get emotion packet fields', () => {

--- a/src/entities/inworld_packet.entity.ts
+++ b/src/entities/inworld_packet.entity.ts
@@ -46,6 +46,7 @@ export interface PacketId {
   packetId: string;
   utteranceId: string;
   interactionId: string;
+  correlationId?: string;
 }
 
 export interface EmotionEvent {
@@ -221,6 +222,7 @@ export class InworldPacket {
         packetId: packetId.getPacketId(),
         utteranceId: packetId.getUtteranceId(),
         interactionId: packetId.getInteractionId(),
+        correlationId: packetId.getCorrelationId(),
       },
       routing: {
         source: {


### PR DESCRIPTION
## Description

Include a correlationId for the overlooked methods.

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3933


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
