### PR TITLE
Allow to use async `onDisconnect` and `onError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add opportunity to generate session token outside of SDK
 - Add `correlationId` to text, custom and cancel response packets
+- Allow to use async `onDisconnect` and `onError`
 
 ## [1.7.0] - 2023-09-01
 

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -37,8 +37,8 @@ export class InworldClient<
   private generateSessionTokenFn: GenerateSessionTokenFn;
   private sessionGetterSetter: GetterSetter<Session>;
 
-  private onDisconnect: (() => void) | undefined;
-  private onError: ((err: ServiceError) => void) | undefined;
+  private onDisconnect: (() => Awaitable<void>) | undefined;
+  private onError: ((err: ServiceError) => Awaitable<void>) | undefined;
   private onMessage: ((message: InworldPacketT) => Awaitable<void>) | undefined;
 
   private extension: Extension<InworldPacketT>;
@@ -82,16 +82,16 @@ export class InworldClient<
     return this;
   }
 
-  setOnDisconnect(fn: () => void) {
+  setOnDisconnect(fn: () => Awaitable<void>) {
     this.onDisconnect = fn;
 
     return this;
   }
 
-  setOnError(fn: (err: ServiceError) => void) {
-    this.onError = (err: ServiceError) => {
+  setOnError(fn: (err: ServiceError) => Awaitable<void>) {
+    this.onError = async (err: ServiceError) => {
       this.logError(err);
-      fn(err);
+      await fn(err);
     };
 
     return this;

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -30,8 +30,8 @@ interface ConnectionProps<InworldPacketT> {
   config?: InternalClientConfiguration;
   sessionGetterSetter?: GetterSetter<Session>;
   sessionContinuation?: SessionContinuation;
-  onDisconnect?: () => void;
-  onError: (err: ServiceError) => void;
+  onDisconnect?: () => Awaitable<void>;
+  onError: (err: ServiceError) => Awaitable<void>;
   onMessage?: (message: InworldPacketT) => Awaitable<void>;
   generateSessionToken?: GenerateSessionTokenFn;
   extension?: Extension<InworldPacketT>;
@@ -61,8 +61,8 @@ export class ConnectionService<
 
   private engineService = new WorldEngineClientGrpcService<InworldPacketT>();
 
-  private onDisconnect: () => void;
-  private onError: (err: ServiceError) => void;
+  private onDisconnect: () => Awaitable<void>;
+  private onError: (err: ServiceError) => Awaitable<void>;
   private onMessage: ((message: ProtoPacket) => Awaitable<void>) | undefined;
 
   private logger = Logger.getInstance();
@@ -70,9 +70,9 @@ export class ConnectionService<
   constructor(props: ConnectionProps<InworldPacketT>) {
     this.connectionProps = props;
 
-    this.onDisconnect = () => {
+    this.onDisconnect = async () => {
       this.state = ConnectionState.INACTIVE;
-      this.connectionProps.onDisconnect?.();
+      await this.connectionProps.onDisconnect?.();
     };
     this.onError = this.connectionProps.onError;
 

--- a/src/services/gprc/world_engine_client_grpc.service.ts
+++ b/src/services/gprc/world_engine_client_grpc.service.ts
@@ -39,8 +39,8 @@ export interface LoadSceneProps<InworldPacketT> {
 }
 export interface SessionProps {
   sessionToken: SessionToken;
-  onDisconnect?: () => void;
-  onError?: (err: ServiceError) => void;
+  onDisconnect?: () => Awaitable<void>;
+  onError?: (err: ServiceError) => Awaitable<void>;
   onMessage?: (message: ProtoPacket) => Awaitable<void>;
 }
 


### PR DESCRIPTION
## Description

We should have opportunity to use async callbacks when it's required

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3887

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
