### PR TITLE
fix: Use parent channel to check channel accessibility for discord bot

### DIFF
--- a/examples/ts/discord_bot/src/bot/guards/channel.guard.ts
+++ b/examples/ts/discord_bot/src/bot/guards/channel.guard.ts
@@ -49,9 +49,13 @@ export class ChannelGuard implements CanActivate {
     }
 
     // General channel
+    const channel = message.channel.isThread()
+      ? message.channel.parent
+      : message.channel.id;
+
     if (
       this.channelsWhitelistEnabled &&
-      !this.channelsWhitelist?.includes(message.channel.id)
+      !this.channelsWhitelist?.includes(channel.id)
     ) {
       return false;
     }


### PR DESCRIPTION
## Description

Use parent channel to check channel accessibility for discord bot

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-4290

## Screenshots (if appropriate)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
