### PR TITLE
fix: Fix the display of text for the CLI example in case audio is delivered before text

### DIFF
--- a/examples/js/cli/components/conversation.js
+++ b/examples/js/cli/components/conversation.js
@@ -22,6 +22,8 @@ class Conversation {
       return;
     }
 
+    this.queue.push({ packet, isApplied: false });
+
     this.player.addToQueue({
       packet,
       onAfterPlaying: (packet) => {

--- a/examples/ts/cli/components/conversation.ts
+++ b/examples/ts/cli/components/conversation.ts
@@ -31,6 +31,8 @@ export class Conversation {
       return;
     }
 
+    this.queue.push({ packet, isApplied: false });
+
     this.player.addToQueue({
       packet,
       onAfterPlaying: (packet: InworldPacket) => {


### PR DESCRIPTION
## Description

Add audio packets in queue before playing 

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/INTG-1286

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
