### PR TITLE
fix: Do not send initial packets twice on open session

### DIFF
--- a/__tests__/services/connection.service.spec.ts
+++ b/__tests__/services/connection.service.spec.ts
@@ -569,6 +569,10 @@ describe('open', () => {
     const openSession = jest
       .spyOn(WorldEngineClientGrpcService.prototype, 'openSession')
       .mockImplementation(() => Promise.resolve([stream, sceneProto]));
+    const reopenSession = jest.spyOn(
+      WorldEngineClientGrpcService.prototype,
+      'reopenSession',
+    );
 
     await connection.open();
 
@@ -577,7 +581,8 @@ describe('open', () => {
     await connection.open();
 
     expect(generateSessionToken).toHaveBeenCalledTimes(2);
-    expect(openSession).toHaveBeenCalledTimes(2);
+    expect(openSession).toHaveBeenCalledTimes(1);
+    expect(reopenSession).toHaveBeenCalledTimes(1);
   });
 
   test('should schedule disconnect', async () => {
@@ -920,7 +925,6 @@ describe('getCharactersList', () => {
       .mockImplementationOnce(() => Promise.resolve(sessionToken));
     const openSession = jest
       .spyOn(WorldEngineClientGrpcService.prototype, 'openSession')
-      .mockImplementationOnce(() => Promise.resolve([stream, sceneProto]))
       .mockImplementationOnce(() => Promise.resolve([stream, sceneProto]));
 
     const loadedCharactersFirst = await connection.getCharactersList();


### PR DESCRIPTION
## Description

If session is already loaded and alive we don't need to resend configuration packets and load scene again. Just open a stream

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/INTG-1506

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
