### PR TITLE
fix: Fix destructuring of empty scene result

### DIFF
--- a/src/services/gprc/world_engine_client_grpc.service.ts
+++ b/src/services/gprc/world_engine_client_grpc.service.ts
@@ -223,9 +223,11 @@ export class WorldEngineClientGrpcService<
 
   updateSession(
     props: UpdateSessionProps<InworldPacketT>,
-  ): Promise<
-    [ClientDuplexStream<ProtoPacket, ProtoPacket>, CurrentSceneStatus]
-  > {
+  ):
+    | Promise<
+        [ClientDuplexStream<ProtoPacket, ProtoPacket>, CurrentSceneStatus]
+      >
+    | [] {
     const { connection, onMessage, sessionToken } = props;
 
     this.logger.debug({
@@ -248,7 +250,7 @@ export class WorldEngineClientGrpcService<
       connection,
     });
 
-    if (!props.name) return;
+    if (!props.name) return [];
 
     connection.removeAllListeners('data');
 


### PR DESCRIPTION
## Description

Otherwise this code doesn't work:
`
const [, sessionProto] = await this.engineService.updateSession(...);`

## Related Issue (for external contributions)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Related Ticket (for Inworld.ai developers)

<!--- Please link to the ticket here: -->

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
